### PR TITLE
Node-kind registry 2/8: derive parse/serialize from descriptor field codecs

### DIFF
--- a/lib/parseChain.ts
+++ b/lib/parseChain.ts
@@ -1,5 +1,6 @@
 import matter from 'gray-matter'
 import { ChainDef, ChainNode, ChainEdge, ChainPort } from './types'
+import { kindOf } from './nodeKinds'
 
 export function parseEndpoint(s: string): { node: string; socket: string } {
   const str = String(s)
@@ -11,23 +12,50 @@ export function parseEndpoint(s: string): { node: string; socket: string } {
 export function parseChainContent(raw: string, slug: string): ChainDef {
   const { data } = matter(raw)
   const nodes: ChainNode[] = Array.isArray(data.nodes)
-    ? data.nodes.map((n: Record<string, unknown>) => ({
-        id: String(n.id),
-        kind: n.kind as ChainNode['kind'],
-        agent: n.agent as string | undefined,
-        file: n.file as string | undefined,
-        pos: Array.isArray(n.pos) ? [Number(n.pos[0]), Number(n.pos[1])] as [number, number] : undefined,
-        condition: n.condition as string | undefined,
-        cases: Array.isArray(n.cases)
-          ? (n.cases as Record<string, unknown>[]).map(c => ({ label: String(c.label), condition: String(c.condition) }))
-          : undefined,
-        default: n.default as string | undefined,
-        zone: n.zone as string | undefined,
-        state: Array.isArray(n.state) ? (n.state as unknown[]).map(String) : undefined,
-        until: n.until as string | undefined,
-        maxIterations: typeof n.maxIterations === 'number' ? n.maxIterations : undefined,
-        subchain: n.subchain as string | undefined,
-      }))
+    ? data.nodes.map((n: Record<string, unknown>) => {
+        const node: Record<string, any> = {
+          id: String(n.id),
+          kind: n.kind as ChainNode['kind'],
+          agent: undefined,
+          file: undefined,
+          pos: Array.isArray(n.pos) ? [Number(n.pos[0]), Number(n.pos[1])] as [number, number] : undefined,
+          condition: undefined,
+          cases: undefined,
+          default: undefined,
+          zone: n.zone as string | undefined,
+          state: undefined,
+          until: undefined,
+          maxIterations: undefined,
+          subchain: undefined,
+        }
+
+        const descriptor = kindOf(node.kind)
+        if (descriptor) {
+          for (const field of descriptor.fields) {
+            const rawVal = n[field.key]
+            if (rawVal === undefined) {
+              continue
+            }
+            switch (field.codec) {
+              case 'string':
+                node[field.key] = String(rawVal)
+                break
+              case 'number':
+                node[field.key] = typeof rawVal === 'number' ? rawVal : undefined
+                break
+              case 'stringList':
+                node[field.key] = Array.isArray(rawVal) ? rawVal.map(String) : undefined
+                break
+              case 'cases':
+                node[field.key] = Array.isArray(rawVal)
+                  ? rawVal.map((c: any) => ({ label: String(c.label), condition: String(c.condition) }))
+                  : undefined
+                break
+            }
+          }
+        }
+        return node as ChainNode
+      })
     : []
   const edges: ChainEdge[] = Array.isArray(data.edges)
     ? data.edges.map((e: Record<string, unknown>) => {

--- a/lib/serializeChain.ts
+++ b/lib/serializeChain.ts
@@ -1,35 +1,26 @@
 import matter from 'gray-matter'
 import { ChainNode, ChainEdge, ChainPort } from './types'
+import { kindOf } from './nodeKinds'
 
 function serializeNode(n: ChainNode): Record<string, unknown> {
   const out: Record<string, unknown> = { id: n.id, kind: n.kind }
   if (n.pos) out.pos = n.pos
   if (n.zone !== undefined) out.zone = n.zone
-  switch (n.kind) {
-    case 'agent':
-    case 'decider':
-      if (n.agent !== undefined) out.agent = n.agent
-      break
-    case 'context':
-      if (n.file !== undefined) out.file = n.file
-      break
-    case 'gate':
-      if (n.condition !== undefined) out.condition = n.condition
-      break
-    case 'branch':
-      if (n.cases) out.cases = n.cases.map(c => ({ label: c.label, condition: c.condition }))
-      if (n.default !== undefined) out.default = n.default
-      break
-    case 'loop-start':
-      if (n.state) out.state = n.state
-      break
-    case 'loop-end':
-      if (n.until !== undefined) out.until = n.until
-      if (n.maxIterations !== undefined) out.maxIterations = n.maxIterations
-      break
-    case 'subchain':
-      if (n.subchain !== undefined) out.subchain = n.subchain
-      break
+
+  const descriptor = kindOf(n.kind)
+  if (descriptor) {
+    for (const field of descriptor.fields) {
+      const val = (n as Record<string, any>)[field.key]
+      if (val !== undefined) {
+        if (field.codec === 'cases') {
+          if (val) {
+            out[field.key] = val.map((c: any) => ({ label: c.label, condition: c.condition }))
+          }
+        } else {
+          out[field.key] = val
+        }
+      }
+    }
   }
   return out
 }


### PR DESCRIPTION
This PR resolves issue #3 by replacing hand-written switches in both `serializeChain.ts` and `parseChain.ts` with generic loops over descriptor fields in the node registry (`lib/nodeKinds.ts`).

### Acceptance Criteria Met:
1. `serializeChain` and `parseChain` contain no per-kind field lists, looping over registry descriptor fields instead.
2. All existing test suites pass unchanged (e.g. `node-kinds.test.ts`, `serialize-chain.test.ts`, `subchain-roundtrip.test.ts`, etc).
3. Serializing each workspace chain in `workspace/chains/` produces byte-identical output before vs after the changes.